### PR TITLE
made the Storage permission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,7 @@ android/app/release/
 node_modules/
 npm-debug.log
 yarn-error.log
-# package-lock.json
+package-lock.json
 
 android/app/google-services.json
 android/keystore.properties

--- a/App.tsx
+++ b/App.tsx
@@ -1,7 +1,10 @@
 import React, {useEffect} from 'react';
-// import 'react-native-reanimated';
-
-import {StatusBar, StyleSheet} from 'react-native';
+import {
+  StatusBar,
+  StyleSheet,
+  PermissionsAndroid,
+  Platform,
+} from 'react-native';
 import {SafeAreaProvider, SafeAreaView} from 'react-native-safe-area-context';
 import Toast from 'react-native-toast-message';
 import MainApp from './src/main';
@@ -14,7 +17,42 @@ enableScreens();
 function App(): React.JSX.Element {
   useEffect(() => {
     SplashScreen.hide();
+    requestStoragePermission();
   }, []);
+
+  const requestStoragePermission = async () => {
+    try {
+      if (Platform.OS === 'android') {
+        if (Platform.Version >= 33) {
+          // Android 13+ (Images, Video, Audio separately)
+          const result = await PermissionsAndroid.requestMultiple([
+            PermissionsAndroid.PERMISSIONS.READ_MEDIA_IMAGES,
+            PermissionsAndroid.PERMISSIONS.READ_MEDIA_VIDEO,
+            PermissionsAndroid.PERMISSIONS.READ_MEDIA_AUDIO,
+          ]);
+          console.log('Android 13+ permission result:', result);
+        } else {
+          // Android 12 and below
+          const granted = await PermissionsAndroid.request(
+            PermissionsAndroid.PERMISSIONS.READ_EXTERNAL_STORAGE,
+            {
+              title: 'Storage Permission Required',
+              message:
+                'ScheduleX needs access to your storage to function properly.',
+              buttonPositive: 'OK',
+            },
+          );
+          if (granted === PermissionsAndroid.RESULTS.GRANTED) {
+            console.log('Storage permission granted');
+          } else {
+            console.log('Storage permission denied');
+          }
+        }
+      }
+    } catch (err) {
+      console.warn(err);
+    }
+  };
 
   return (
     <SafeAreaProvider>
@@ -44,4 +82,5 @@ const styles = StyleSheet.create({
     backgroundColor: '#18181B',
   },
 });
+
 export default App;

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <uses-permission android:name="android.permission.INTERNET" />
+  <uses-permission android:name="android.permission.INTERNET" />
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application
       android:name=".MainApplication"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,17 +4,13 @@
     <!-- Internet access -->
     <uses-permission android:name="android.permission.INTERNET" />
 
-    <!-- For Android 13+ (API 33+) -->
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
-    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
-
     <!-- For Android 10 and below -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="29" />
 
-    <!-- Optional: only if your app is a file manager or needs all-file access -->
+    <!-- For Android 11+ -->
+    <!-- Only use MANAGE_EXTERNAL_STORAGE if you need full access, else rely on SAF -->
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
 
     <application
@@ -40,6 +36,17 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <!-- FileProvider for exporting/importing CSV safely -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
 
     </application>
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,32 +1,45 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.schedulex">
 
-  <uses-permission android:name="android.permission.INTERNET" />
-  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <!-- Internet access -->
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <!-- For Android 13+ (API 33+) -->
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+
+    <!-- For Android 10 and below -->
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="29" />
+
+    <!-- Optional: only if your app is a file manager or needs all-file access -->
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
 
     <application
-      android:name=".MainApplication"
-      android:label="@string/app_name"
-      android:icon="@mipmap/ic_launcher"
-      android:roundIcon="@mipmap/ic_launcher_round"
-      android:allowBackup="false"
-      android:theme="@style/AppTheme"
-      android:supportsRtl="true">
-
-      <activity
-        android:name=".MainActivity"
+        android:name=".MainApplication"
         android:label="@string/app_name"
-        android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
-        android:launchMode="singleTask"
-        android:windowSoftInputMode="adjustResize"
-        android:exported="true"
-        android:screenOrientation="portrait"
-        >
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:allowBackup="false"
+        android:theme="@style/AppTheme"
+        android:supportsRtl="true">
 
-        <intent-filter>
-            <action android:name="android.intent.action.MAIN" />
-            <category android:name="android.intent.category.LAUNCHER" />
-        </intent-filter>
-      </activity>
+        <activity
+            android:name=".MainActivity"
+            android:label="@string/app_name"
+            android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
+            android:launchMode="singleTask"
+            android:windowSoftInputMode="adjustResize"
+            android:exported="true"
+            android:screenOrientation="portrait">
+
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
     </application>
-
 </manifest>

--- a/android/app/src/main/res/xml/file_paths.xml
+++ b/android/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path name="external_files" path="." />
+</paths>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         minSdkVersion = 24
         compileSdkVersion = 35
         targetSdkVersion = 35
-       ndkVersion = "26.3.11579264"
+       ndkVersion = "27.1.12297006"
         kotlinVersion = "2.0.21"
     }
     repositories {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         minSdkVersion = 24
         compileSdkVersion = 35
         targetSdkVersion = 35
-       ndkVersion = "27.1.12297006"
+       ndkVersion = "26.3.11579264"
         kotlinVersion = "2.0.21"
     }
     repositories {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react-native-linear-gradient": "^2.8.3",
     "react-native-multiple-select": "^0.5.12",
     "react-native-pager-view": "^6.8.1",
+    "react-native-permissions": "^5.4.2",
     "react-native-safe-area-context": "^5.0.0",
     "react-native-screens": "^4.3.0",
     "react-native-share": "^12.1.0",

--- a/src/utils/exportSchedule.ts
+++ b/src/utils/exportSchedule.ts
@@ -3,6 +3,7 @@ import { Alert, ToastAndroid, Platform, PermissionsAndroid } from 'react-native'
 import Share from 'react-native-share';
 import { generateRegisterCSV } from './csv-export';
 import { CardInterface } from '../types/cards';
+import { PermissionsHelper } from './permissions';
 
 export interface ExportResult {
   path: string;
@@ -25,25 +26,9 @@ export class ExportScheduleUtility {
   }
 
   private async checkStoragePermission(): Promise<boolean> {
-    if (Platform.OS === 'android') {
-      try {
-        const granted = await PermissionsAndroid.request(
-          PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE,
-          {
-            title: 'Storage Permission',
-            message: 'App needs access to storage to save CSV files',
-            buttonNeutral: 'Ask Me Later',
-            buttonNegative: 'Cancel',
-            buttonPositive: 'OK',
-          }
-        );
-        return granted === PermissionsAndroid.RESULTS.GRANTED;
-      } catch (err) {
-        console.warn(err);
-        return false;
-      }
-    }
-    return true; // iOS doesn't need explicit storage permission for app documents
+    // Use PermissionsHelper for consistent permission logic
+    const result = await PermissionsHelper.requestStoragePermission();
+    return result.granted;
   }
 
   private getAllRegisterIds(): number[] {

--- a/src/utils/exportSchedule.ts
+++ b/src/utils/exportSchedule.ts
@@ -1,3 +1,29 @@
+/**
+ * Rename an exported CSV file in the Downloads directory.
+ * @param oldName The current filename (with .csv)
+ * @param newName The new filename (without .csv or with .csv)
+ * @returns Promise<boolean> true if successful, false otherwise
+ */
+export async function renameExportedCSV(oldName: string, newName: string): Promise<boolean> {
+  try {
+    const downloadsDir = RNFS.DownloadDirectoryPath;
+    const oldPath = `${downloadsDir}/${oldName}`;
+    let newFileName = newName.endsWith('.csv') ? newName : `${newName}.csv`;
+    const newPath = `${downloadsDir}/${newFileName}`;
+    const exists = await RNFS.exists(oldPath);
+    if (!exists) {
+      Alert.alert('Rename Failed', `File ${oldName} does not exist.`);
+      return false;
+    }
+    await RNFS.moveFile(oldPath, newPath);
+    ToastAndroid.show(`Renamed to ${newFileName}`, ToastAndroid.SHORT);
+    return true;
+  } catch (e) {
+    console.error('Rename error:', e);
+    Alert.alert('Rename Failed', `Could not rename file: ${e instanceof Error ? e.message : 'Unknown error'}`);
+    return false;
+  }
+}
 import RNFS from 'react-native-fs';
 import { Alert, ToastAndroid, Platform, PermissionsAndroid } from 'react-native';
 import Share from 'react-native-share';

--- a/src/utils/exportSchedule.ts
+++ b/src/utils/exportSchedule.ts
@@ -1,29 +1,3 @@
-/**
- * Rename an exported CSV file in the Downloads directory.
- * @param oldName The current filename (with .csv)
- * @param newName The new filename (without .csv or with .csv)
- * @returns Promise<boolean> true if successful, false otherwise
- */
-export async function renameExportedCSV(oldName: string, newName: string): Promise<boolean> {
-  try {
-    const downloadsDir = RNFS.DownloadDirectoryPath;
-    const oldPath = `${downloadsDir}/${oldName}`;
-    let newFileName = newName.endsWith('.csv') ? newName : `${newName}.csv`;
-    const newPath = `${downloadsDir}/${newFileName}`;
-    const exists = await RNFS.exists(oldPath);
-    if (!exists) {
-      Alert.alert('Rename Failed', `File ${oldName} does not exist.`);
-      return false;
-    }
-    await RNFS.moveFile(oldPath, newPath);
-    ToastAndroid.show(`Renamed to ${newFileName}`, ToastAndroid.SHORT);
-    return true;
-  } catch (e) {
-    console.error('Rename error:', e);
-    Alert.alert('Rename Failed', `Could not rename file: ${e instanceof Error ? e.message : 'Unknown error'}`);
-    return false;
-  }
-}
 import RNFS from 'react-native-fs';
 import { Alert, ToastAndroid, Platform, PermissionsAndroid } from 'react-native';
 import Share from 'react-native-share';

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -1,4 +1,136 @@
-import { Platform, PermissionsAndroid, Alert } from 'react-native';
+// import { Platform, Alert } from 'react-native';
+// import { check, request, PERMISSIONS, RESULTS, openSettings } from 'react-native-permissions';
+
+// export interface PermissionResult {
+//   granted: boolean;
+//   canRequestAgain: boolean;
+// }
+
+// export class PermissionsHelper {
+  
+//   /**
+//    * Check if we need to request storage permissions based on Android version
+//    * Android 11+ (API 30+) uses scoped storage, so we don't need WRITE_EXTERNAL_STORAGE
+//    * for app-specific directories
+//    */
+//   static needsStoragePermission(): boolean {
+//     return Platform.OS === 'android';
+//   }
+
+//   /**
+//    * Request storage permissions for Android
+//    */
+//   static async requestStoragePermission(): Promise<PermissionResult> {
+//     if (Platform.OS === 'android') {
+//       const permission = PERMISSIONS.ANDROID.READ_EXTERNAL_STORAGE;
+//       try {
+//         const result = await request(permission);
+//         if (result === RESULTS.GRANTED) {
+//           return { granted: true, canRequestAgain: false };
+//         } else if (result === RESULTS.BLOCKED) {
+//           return { granted: false, canRequestAgain: false };
+//         } else {
+//           return { granted: false, canRequestAgain: true };
+//         }
+//       } catch (error) {
+//         console.warn('Permission request error:', error);
+//         return { granted: false, canRequestAgain: true };
+//       }
+//     } else if (Platform.OS === 'ios') {
+//       const permission = PERMISSIONS.IOS.PHOTO_LIBRARY;
+//       try {
+//         const result = await request(permission);
+//         if (result === RESULTS.GRANTED) {
+//           return { granted: true, canRequestAgain: false };
+//         } else if (result === RESULTS.BLOCKED) {
+//           return { granted: false, canRequestAgain: false };
+//         } else {
+//           return { granted: false, canRequestAgain: true };
+//         }
+//       } catch (error) {
+//         console.warn('Permission request error:', error);
+//         return { granted: false, canRequestAgain: true };
+//       }
+//     }
+//     return { granted: true, canRequestAgain: false };
+//   }
+
+//   /**
+//    * Check if storage permissions are currently granted
+//    */
+//   static async checkStoragePermission(): Promise<boolean> {
+//     if (Platform.OS === 'android') {
+//       const permission = PERMISSIONS.ANDROID.READ_EXTERNAL_STORAGE;
+//       try {
+//         const result = await check(permission);
+//         return result === RESULTS.GRANTED;
+//       } catch (error) {
+//         console.warn('Permission check error:', error);
+//         return false;
+//       }
+//     } else if (Platform.OS === 'ios') {
+//       const permission = PERMISSIONS.IOS.PHOTO_LIBRARY;
+//       try {
+//         const result = await check(permission);
+//         return result === RESULTS.GRANTED;
+//       } catch (error) {
+//         console.warn('Permission check error:', error);
+//         return false;
+//       }
+//     }
+//     return true;
+//   }
+
+//   /**
+//    * Show permission explanation dialog
+//    */
+//   static showPermissionExplanation(onRetry: () => void, onCancel: () => void) {
+//     Alert.alert(
+//       'Storage Permission Required',
+//       'This app needs storage permission to save CSV files to your device. You can still use the share feature without this permission.',
+//       [
+//         {
+//           text: 'Cancel',
+//           style: 'cancel',
+//           onPress: onCancel,
+//         },
+//         {
+//           text: 'Grant Permission',
+//           onPress: onRetry,
+//         },
+//       ]
+//     );
+//   }
+
+//   /**
+//    * Show permission denied dialog
+//    */
+//   static showPermissionDenied(onUseAppStorage: () => void) {
+//     Alert.alert(
+//       'Permission Denied',
+//       'Storage permission was denied. You can either:\n\n1. Enable it in Settings\n2. Use app storage (files will be saved in app folder)',
+//       [
+//         {
+//           text: 'Use App Storage',
+//           onPress: onUseAppStorage,
+//         },
+//         {
+//           text: 'Open Settings',
+//           onPress: () => openSettings(),
+//         },
+//       ]
+//     );
+//   }
+// }
+
+import { Platform, Alert } from "react-native";
+import {
+  check,
+  request,
+  PERMISSIONS,
+  RESULTS,
+  openSettings,
+} from "react-native-permissions";
 
 export interface PermissionResult {
   granted: boolean;
@@ -6,96 +138,84 @@ export interface PermissionResult {
 }
 
 export class PermissionsHelper {
-  
   /**
    * Check if we need to request storage permissions based on Android version
-   * Android 11+ (API 30+) uses scoped storage, so we don't need WRITE_EXTERNAL_STORAGE
-   * for app-specific directories
    */
   static needsStoragePermission(): boolean {
-    if (Platform.OS !== 'android') return false;
-    
-    // For Android 11+ (API 30+), we use app-scoped storage which doesn't require permissions
-    const androidVersion = Platform.Version as number;
-    return androidVersion < 30;
+    return Platform.OS === "android";
   }
 
   /**
-   * Request storage permissions for Android
+   * Request storage permissions for Android & iOS
    */
-  static async requestStoragePermission(forPublicStorage: boolean = false): Promise<PermissionResult> {
-    if (Platform.OS !== 'android') {
-      return { granted: true, canRequestAgain: false };
-    }
+  static async requestStoragePermission(): Promise<PermissionResult> {
+    if (Platform.OS === "android") {
+      // For Android 11+, rely on Document Picker instead of MANAGE_EXTERNAL_STORAGE
+      const permission =
+        Platform.Version >= 30
+          ? PERMISSIONS.ANDROID.READ_EXTERNAL_STORAGE
+          : PERMISSIONS.ANDROID.WRITE_EXTERNAL_STORAGE;
 
-    // Android 11+ doesn't need storage permissions for app-scoped directories
-    if (!this.needsStoragePermission() && !forPublicStorage) {
-      return { granted: true, canRequestAgain: false };
-    }
-
-    try {
-      // For Android 10 and below, or if explicitly requesting public storage
-      if (this.needsStoragePermission() || forPublicStorage) {
-        const writeResult = await PermissionsAndroid.request(
-          PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE,
-          {
-            title: 'Storage Permission',
-            message: 'App needs storage permission to save CSV files',
-            buttonNeutral: 'Ask Me Later',
-            buttonNegative: 'Cancel',
-            buttonPositive: 'OK',
-          }
-        );
-        
-        const readResult = await PermissionsAndroid.request(
-          PermissionsAndroid.PERMISSIONS.READ_EXTERNAL_STORAGE,
-          {
-            title: 'Storage Permission',
-            message: 'App needs storage permission to access files',
-            buttonNeutral: 'Ask Me Later',
-            buttonNegative: 'Cancel',
-            buttonPositive: 'OK',
-          }
-        );
-
-        const allGranted = writeResult === PermissionsAndroid.RESULTS.GRANTED && 
-                          readResult === PermissionsAndroid.RESULTS.GRANTED;
-        
-        const canRequestAgain = writeResult !== PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN &&
-                               readResult !== PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN;
-
-        return {
-          granted: allGranted,
-          canRequestAgain
-        };
+      try {
+        const result = await request(permission);
+        if (result === RESULTS.GRANTED) {
+          return { granted: true, canRequestAgain: false };
+        } else if (result === RESULTS.BLOCKED) {
+          return { granted: false, canRequestAgain: false };
+        } else {
+          return { granted: false, canRequestAgain: true };
+        }
+      } catch (error) {
+        console.warn("Permission request error:", error);
+        return { granted: false, canRequestAgain: true };
       }
-
-      return { granted: true, canRequestAgain: false };
-
-    } catch (error) {
-      console.warn('Permission request error:', error);
-      return { granted: false, canRequestAgain: true };
+    } else if (Platform.OS === "ios") {
+      const permission = PERMISSIONS.IOS.PHOTO_LIBRARY_ADD_ONLY;
+      try {
+        const result = await request(permission);
+        if (result === RESULTS.GRANTED) {
+          return { granted: true, canRequestAgain: false };
+        } else if (result === RESULTS.BLOCKED) {
+          return { granted: false, canRequestAgain: false };
+        } else {
+          return { granted: false, canRequestAgain: true };
+        }
+      } catch (error) {
+        console.warn("Permission request error:", error);
+        return { granted: false, canRequestAgain: true };
+      }
     }
+    return { granted: true, canRequestAgain: false };
   }
 
   /**
    * Check if storage permissions are currently granted
    */
   static async checkStoragePermission(): Promise<boolean> {
-    if (Platform.OS !== 'android') return true;
-    
-    if (!this.needsStoragePermission()) return true;
+    if (Platform.OS === "android") {
+      const permission =
+        Platform.Version >= 30
+          ? PERMISSIONS.ANDROID.READ_EXTERNAL_STORAGE
+          : PERMISSIONS.ANDROID.WRITE_EXTERNAL_STORAGE;
 
-    try {
-      const writePermission = await PermissionsAndroid.check(
-        PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE
-      );
-      
-      return writePermission;
-    } catch (error) {
-      console.warn('Permission check error:', error);
-      return false;
+      try {
+        const result = await check(permission);
+        return result === RESULTS.GRANTED;
+      } catch (error) {
+        console.warn("Permission check error:", error);
+        return false;
+      }
+    } else if (Platform.OS === "ios") {
+      const permission = PERMISSIONS.IOS.PHOTO_LIBRARY_ADD_ONLY;
+      try {
+        const result = await check(permission);
+        return result === RESULTS.GRANTED;
+      } catch (error) {
+        console.warn("Permission check error:", error);
+        return false;
+      }
     }
+    return true;
   }
 
   /**
@@ -103,16 +223,16 @@ export class PermissionsHelper {
    */
   static showPermissionExplanation(onRetry: () => void, onCancel: () => void) {
     Alert.alert(
-      'Storage Permission Required',
-      'This app needs storage permission to save CSV files to your device. You can still use the share feature without this permission.',
+      "Storage Permission Required",
+      "This app needs storage permission to save CSV files to your device. You can still use the share feature without this permission.",
       [
         {
-          text: 'Cancel',
-          style: 'cancel',
+          text: "Cancel",
+          style: "cancel",
           onPress: onCancel,
         },
         {
-          text: 'Grant Permission',
+          text: "Grant Permission",
           onPress: onRetry,
         },
       ]
@@ -122,18 +242,18 @@ export class PermissionsHelper {
   /**
    * Show permission denied dialog
    */
-  static showPermissionDenied(onOpenSettings: () => void, onUseAppStorage: () => void) {
+  static showPermissionDenied(onUseAppStorage: () => void) {
     Alert.alert(
-      'Permission Denied',
-      'Storage permission was denied. You can either:\n\n1. Enable it in Settings\n2. Use app storage (files will be saved in app folder)',
+      "Permission Denied",
+      "Storage permission was denied. You can either:\n\n1. Enable it in Settings\n2. Use app storage (files will be saved in app folder)",
       [
         {
-          text: 'Use App Storage',
+          text: "Use App Storage",
           onPress: onUseAppStorage,
         },
         {
-          text: 'Open Settings',
-          onPress: onOpenSettings,
+          text: "Open Settings",
+          onPress: () => openSettings(),
         },
       ]
     );

--- a/src/utils/storage-permissions.ts
+++ b/src/utils/storage-permissions.ts
@@ -1,0 +1,6 @@
+import { PermissionsHelper } from './permissions';
+
+export const requestStoragePermission = async (): Promise<boolean> => {
+	const result = await PermissionsHelper.requestStoragePermission();
+	return result.granted;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -6778,7 +6778,7 @@ react-native-dotenv@^3.4.11:
 
 react-native-fs@^2.20.0:
   version "2.20.0"
-  resolved "https://registry.npmjs.org/react-native-fs/-/react-native-fs-2.20.0.tgz"
+  resolved "https://registry.yarnpkg.com/react-native-fs/-/react-native-fs-2.20.0.tgz#05a9362b473bfc0910772c0acbb73a78dbc810f6"
   integrity sha512-VkTBzs7fIDUiy/XajOSNk0XazFE9l+QlMAce7lGuebZcag5CnjszB+u4BdqzwaQOdcYb5wsJIsqq4kxInIRpJQ==
   dependencies:
     base-64 "^0.1.0"
@@ -6829,6 +6829,11 @@ react-native-pager-view@^6.8.1:
   version "6.8.1"
   resolved "https://registry.npmjs.org/react-native-pager-view/-/react-native-pager-view-6.8.1.tgz"
   integrity sha512-XIyVEMhwq7sZqM7GobOJZXxFCfdFgVNq/CFB2rZIRNRSVPJqE1k1fsc8xfQKfdzsp6Rpt6I7VOIvhmP7/YHdVg==
+
+react-native-permissions@^5.4.2:
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/react-native-permissions/-/react-native-permissions-5.4.2.tgz#206c0e440cff2ce047514995457bd73a9924fd8b"
+  integrity sha512-XNMoG1fxrB9q73MLn/ZfTaP7pS8qPu0KWypbeFKVTvoR+JJ3O7uedMOTH/mts9bTG+GKhShOoZ+k0CR63q9jwA==
 
 react-native-safe-area-context@^5.0.0:
   version "5.5.2"


### PR DESCRIPTION
## Fixes

Closes #127 

## Description
This pull request introduces improvements to how storage permissions are handled in the Android app, refactors permission logic for better maintainability, and updates build configuration. The main changes include switching to a centralized permissions helper, updating Android manifest permissions, and modifying the NDK version in the build configuration.

**Permissions handling and refactoring:**

* Replaced manual storage permission request logic in `ExportScheduleUtility` with a call to `PermissionsHelper.requestStoragePermission`, ensuring consistent permission management across the app (`src/utils/exportSchedule.ts`).
* Added a new utility function `requestStoragePermission` in `src/utils/storage-permissions.ts` that delegates permission handling to `PermissionsHelper` for easier reuse and testing.
* Imported `PermissionsHelper` into `exportSchedule.ts` for centralized permission logic.

**Android configuration:**

* Added `android.permission.WRITE_EXTERNAL_STORAGE` to `AndroidManifest.xml` to explicitly request storage access on Android devices.
* Updated the NDK version in `android/build.gradle` from `27.1.12297006` to `26.3.11579264` for compatibility or build stability.
<!-- Briefly describe what changes you made -->

## Files Changed

- [.gitignore](https://github.com/Loop-Hive/ScheduleX/compare/main...FireFistisDead:ScheduleX:main?expand=1#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947)
-  [android/app/src/main/AndroidManifest.xml](https://github.com/Loop-Hive/ScheduleX/compare/main...FireFistisDead:ScheduleX:main?expand=1#diff-63272c98a6330850888e633b43ba4c9decee6431a115e0d2731564838eaa1d1d)
- [src/components/GlobalRegisterSelector.tsx](https://github.com/Loop-Hive/ScheduleX/compare/main...FireFistisDead:ScheduleX:main?expand=1#diff-17396b3f2f525e0629ae52a0cb511ff97e23dce6db75bfc83745bd225c9d0018)
-  [src/utils/exportSchedule.ts](https://github.com/Loop-Hive/ScheduleX/compare/main...FireFistisDead:ScheduleX:main?expand=1#diff-b3ba0697527cd1983a6a625e21b357bfd1e50db3f078dbc79aebdd9b8058c39a)
-  [src/utils/storage-permissions.ts](https://github.com/Loop-Hive/ScheduleX/compare/main...FireFistisDead:ScheduleX:main?expand=1#diff-f87e6e2e838798140fa5f28819ce058cee677662a7520bcc737078f9baf16d5d)

## GSSoC Contributor

- [ ] Yes, I am a GSSoC contributor

## Testing Device
- [ ] Physical Android Device

