### PR TITLE
resolved the export csv for android 13+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ android/app/release-key.jks
 !.yarn/sdks
 !.yarn/versions
 yarn.lock
+
+.env

--- a/src/utils/exportSchedule.ts
+++ b/src/utils/exportSchedule.ts
@@ -40,12 +40,7 @@ export class ExportScheduleUtility {
       console.log('Starting export with selectedRegisters:', this.selectedRegisters);
       console.log('Available registers:', Object.keys(this.registers));
       
-      // Check storage permission first
-      const hasPermission = await this.checkStoragePermission();
-      if (!hasPermission) {
-        Alert.alert('Permission Denied', 'Storage permission is required to save CSV files.');
-        return null;
-      }
+  // No permission needed for app-specific external storage on Android 13+
       
       if (this.selectedRegisters.length === 0) {
         Alert.alert('Export Failed', 'No registers selected for export.');
@@ -86,16 +81,20 @@ export class ExportScheduleUtility {
         return null;
       }
 
-      const path = `${RNFS.DownloadDirectoryPath}/${fileName}`;
-      console.log('Export path:', path);
-      
-      // Ensure the directory exists
-      const dirPath = RNFS.DownloadDirectoryPath;
-      const dirExists = await RNFS.exists(dirPath);
+      // WhatsApp-like: Save in Android/media/com.schedulex/ScheduleX
+      console.log('RNFS.ExternalStorageDirectoryPath:', RNFS.ExternalStorageDirectoryPath);
+      const scheduleXDir = `${RNFS.ExternalStorageDirectoryPath}/Android/media/com.schedulex/ScheduleX`;
+      const dirExists = await RNFS.exists(scheduleXDir);
       if (!dirExists) {
-        await RNFS.mkdir(dirPath);
+        try {
+          await RNFS.mkdir(scheduleXDir);
+          console.log('Created folder:', scheduleXDir);
+        } catch (e) {
+          console.error('Error creating folder:', e);
+        }
       }
-      
+      const path = `${scheduleXDir}/${fileName}`;
+      console.log('Export path:', path);
       const exists = await RNFS.exists(path);
 
       if (checkOnly && exists) {


### PR DESCRIPTION
## Fixes

Closes #135 

## Description
This pull request updates the logic for exporting schedule data to external storage on Android devices. The main changes focus on improving compatibility with Android 13+ by removing unnecessary storage permission checks and saving exported files in an app-specific directory similar to WhatsApp, which enhances user privacy and file organization.

**Android storage compatibility improvements:**

* Removed the check for storage permissions, since app-specific external storage on Android 13+ does not require explicit permission.
* Changed the export directory to `Android/media/com.schedulex/ScheduleX` within `RNFS.ExternalStorageDirectoryPath`, ensuring files are saved in a modern, app-specific location. Added logic to create this directory if it does not exist.


## Files Changed

- [.gitignore](https://github.com/Loop-Hive/ScheduleX/compare/main...FireFistisDead:ScheduleX:bug/dsv-permission-av+13?expand=1#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947)
- [src/utils/exportSchedule.ts](https://github.com/Loop-Hive/ScheduleX/compare/main...FireFistisDead:ScheduleX:bug/dsv-permission-av+13?expand=1#diff-b3ba0697527cd1983a6a625e21b357bfd1e50db3f078dbc79aebdd9b8058c39a)

## Screenshots/Videos
https://drive.google.com/file/d/1poyKeMP3EY-B3JIZ7BG3dMFO-QSp4FPE/view?usp=sharing


## GSSoC Contributor

- [ ] Yes, I am a GSSoC contributor


## Testing Device
- [ ] Physical Android Device
