### PR TITLE
Fix dropdown overflow

### DIFF
--- a/src/screens/time-table/TimeTableScreen.tsx
+++ b/src/screens/time-table/TimeTableScreen.tsx
@@ -6,6 +6,7 @@ import {
   Text,
   TouchableOpacity,
   Image,
+  ScrollView,
 } from 'react-native';
 import TimeTable from './components/TimeTable';
 import useStore from '../../store/store';
@@ -223,6 +224,7 @@ const TimeTableScreen: React.FC<TimeTableScreenProps> = ({
                   </Text>
                 </View>
               </TouchableOpacity>
+              <ScrollView style={{ maxHeight: 160 }}>
               {getAllRegisterIds().map(registerId => (
                 <TouchableOpacity
                   key={registerId}
@@ -257,6 +259,7 @@ const TimeTableScreen: React.FC<TimeTableScreenProps> = ({
                   </View>
                 </TouchableOpacity>
               ))}
+              </ScrollView>
             </View>
           )}
         </View>


### PR DESCRIPTION
## Fixes #111 

## Description
Fixed the issue where the register select dropdown menu overflowed off the screen when more than 3–4 registers were added. Wrapped the dropdown in a scrollable container with a max height to ensure all options are visible and scrollable.

## Files Changed

- [x] src/screens/time-table/TimeTableScreen.tsx

## GSSoC Contributor

- [x] Yes, I am a GSSoC contributor
- [ ] No, I am not a GSSoC contributor

## Testing Device

- [x] Android Emulator
- [ ] iOS Simulator
- [ ] Physical Android Device
- [ ] Physical iOS Device
